### PR TITLE
Organize chat, PDF viewer and menu columns

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Assistant from "@/components/assistant";
 import ToolsPanel from "@/components/tools-panel";
+import PdfViewer from "@/components/pdf-viewer";
 import { Menu, X } from "lucide-react";
 import { useState } from "react";
 
@@ -8,11 +9,14 @@ export default function Main() {
   const [isToolsPanelOpen, setIsToolsPanelOpen] = useState(false);
 
   return (
-    <div className="flex justify-center h-screen">
-      <div className="w-full md:w-[70%]">
+    <div className="flex h-screen">
+      <div className="w-full md:w-1/4">
         <Assistant />
       </div>
-      <div className=" hidden md:block w-[30%]">
+      <div className="hidden md:block w-1/2">
+        <PdfViewer />
+      </div>
+      <div className="hidden md:block w-1/4">
         <ToolsPanel />
       </div>
       {/* Hamburger menu for small screens */}
@@ -24,10 +28,11 @@ export default function Main() {
       {/* Overlay panel for ToolsPanel on small screens */}
       {isToolsPanelOpen && (
         <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30">
-          <div className="w-full bg-white h-full p-4">
+          <div className="w-full bg-white h-full p-4 overflow-y-auto">
             <button className="mb-4" onClick={() => setIsToolsPanelOpen(false)}>
               <X size={24} />
             </button>
+            <PdfViewer />
             <ToolsPanel />
           </div>
         </div>

--- a/components/tools-panel.tsx
+++ b/components/tools-panel.tsx
@@ -6,7 +6,6 @@ import FunctionsView from "./functions-view";
 import McpConfig from "./mcp-config";
 import PanelConfig from "./panel-config";
 import useToolsStore from "@/stores/useToolsStore";
-import PdfViewer from "./pdf-viewer";
 
 export default function ContextPanel() {
   const {
@@ -62,7 +61,6 @@ export default function ContextPanel() {
         >
           <McpConfig />
         </PanelConfig>
-        <PdfViewer />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- restructure main page with chat left, PDF viewer center and menu right
- move PDF viewer out of ToolsPanel so it renders independently
- show PDF viewer alongside menu in mobile overlay

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6893630fbcd0832284c57c395ed0818d